### PR TITLE
Remove https option, it's confusing and can break things

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,7 +13,6 @@ import (
 type Configuration struct {
 	Listen      string `config:"tcp://:8080"`
 	Host        string `config:"localhost:8080"`
-	Scheme      string `config:"https"`
 	MetaDB      string `config:"lfs.db"`
 	ContentPath string `config:"lfs-content"`
 	AdminUser   string `config:""`

--- a/harbour_test.go
+++ b/harbour_test.go
@@ -305,8 +305,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	Config.Scheme = "http"
-
 	os.Remove("lfs-test.db")
 
 	var err error

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 const (
 	contentMediaType = "application/vnd.git-lfs"
 	metaMediaType    = contentMediaType + "+json"
-	version          = "0.1.1"
+	version          = "0.1.2"
 )
 
 var (

--- a/server.go
+++ b/server.go
@@ -41,7 +41,7 @@ type Representation struct {
 // ObjectLink builds a URL linking to the object.
 func (v *RequestVars) ObjectLink() string {
 	path := fmt.Sprintf("/%s/%s/objects/%s", v.User, v.Repo, v.Oid)
-	return fmt.Sprintf("%s://%s%s", Config.Scheme, Config.Host, path)
+	return fmt.Sprintf("http://%s%s", Config.Host, path)
 }
 
 // link provides a structure used to build a hypermedia representation of an HTTP link.


### PR DESCRIPTION
The `LFS_SCHEME` setting doesn't actually cover all of the http operations, which is confusing. Being just a test server, we can operate only in http, further promoting the fact that it shouldn't be used in production :smile:

Reported in #16 