### PR TITLE
Fix download authorization issue

### DIFF
--- a/server.go
+++ b/server.go
@@ -244,14 +244,14 @@ func (a *App) Represent(rv *RequestVars, meta *MetaObject, download, upload bool
 		Links: make(map[string]*link),
 	}
 
+	header := make(map[string]string)
+	header["Accept"] = contentMediaType
+	header["Authorization"] = rv.Authorization
 	if download {
-		rep.Links["download"] = &link{Href: rv.ObjectLink(), Header: map[string]string{"Accept": contentMediaType}}
+		rep.Links["download"] = &link{Href: rv.ObjectLink(), Header: header}
 	}
 
 	if upload {
-		header := make(map[string]string)
-		header["Accept"] = contentMediaType
-		header["Authorization"] = rv.Authorization
 		rep.Links["upload"] = &link{Href: rv.ObjectLink(), Header: header}
 	}
 	return rep


### PR DESCRIPTION
I setup local test git repository with ssh access.
On server I create simple ```git-lfs-authenticate``` script:
```
#!/bin/sh
echo '{
  "href": "http://git.test.local:9999/test/test",
  "header": {
    "Authorization": "Basic dGVzdDp0ZXN0"
  }
}'
```
After this I try to checkout repository with LFS files.

On every LFS file I got a password request:

 * git-lfs sucessfully download metadata with provided by ```git-lfs-authenticate``` Authorization;
 * metadata does not contains any Authorization data;
 * git-lfs try to download content without Authorization data and got 401 error.