### PR TITLE
Trivial typo in  error message.

### DIFF
--- a/content_store.go
+++ b/content_store.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	errHashMismatch = errors.New("Content has does not match OID")
+	errHashMismatch = errors.New("Content hash does not match OID")
 	errSizeMismatch = errors.New("Content size does not match")
 )
 


### PR DESCRIPTION
"has" ==> "hash"