### PR TITLE
Resumable uploads via tusd

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ There are few things that can be configured via environment variables:
 	LFS_CERT        # Certificate file for tls
 	LFS_KEY         # tls key
 	LFS_SCHEME      # set to 'https' to override default http
+    LFS_USETUS      # set to 'true' to enable tusd (tus.io) resumable upload server; tusd must be on PATH, installed separately
+    LFS_TUSHOST     # The host used to start the tusd upload server, default "localhost:1080"
 
 If the `LFS_ADMINUSER` and `LFS_ADMINPASS` variables are set, a
 rudimentary admin interface can be accessed via

--- a/config.go
+++ b/config.go
@@ -21,6 +21,8 @@ type Configuration struct {
 	Key         string `config:""`
 	Scheme      string `config:"http"`
 	Public      string `config:"public"`
+	UseTus      string `config:"false"`
+	TusHost     string `config:"localhost:1080"`
 }
 
 func (c *Configuration) IsHTTPS() bool {
@@ -29,6 +31,14 @@ func (c *Configuration) IsHTTPS() bool {
 
 func (c *Configuration) IsPublic() bool {
 	switch Config.Public {
+	case "1", "true", "TRUE":
+		return true
+	}
+	return false
+}
+
+func (c *Configuration) IsUsingTus() bool {
+	switch Config.UseTus {
 	case "1", "true", "TRUE":
 		return true
 	}

--- a/main.go
+++ b/main.go
@@ -107,6 +107,12 @@ func main() {
 	logger.Log(kv{"fn": "main", "msg": "listening", "pid": os.Getpid(), "addr": Config.Listen, "version": version})
 
 	app := NewApp(contentStore, metaStore)
+	if Config.IsUsingTus() {
+		tusServer.Start()
+	}
 	app.Serve(listener)
 	tl.WaitForChildren()
+	if Config.IsUsingTus() {
+		tusServer.Stop()
+	}
 }

--- a/tus.go
+++ b/tus.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type TusServer struct {
+	serverMutex sync.Mutex
+	tusProcess  *exec.Cmd
+	dataPath    string
+	tusBaseUrl  string
+	httpClient  *http.Client
+	oidToTusUrl map[string]string
+}
+
+var (
+	tusServer *TusServer = &TusServer{}
+)
+
+// Start launches the tus server & stores uploads in the given contentPath
+func (t *TusServer) Start() {
+	t.serverMutex.Lock()
+	defer t.serverMutex.Unlock()
+
+	if t.tusProcess != nil {
+		return
+	}
+
+	t.dataPath = filepath.Join(os.TempDir(), "lfs_tusserver")
+	hostparts := strings.Split(Config.TusHost, ":")
+	host := "localhost"
+	port := "1080"
+	if len(hostparts) > 0 {
+		host = hostparts[0]
+	}
+	if len(hostparts) > 1 {
+		port = hostparts[1]
+	}
+	t.tusProcess = exec.Command("tusd",
+		"-dir", t.dataPath,
+		"-host", host,
+		"-port", port)
+	// Make sure tus server is started before continuing
+	var procWait sync.WaitGroup
+	procWait.Add(1)
+	go func(p *exec.Cmd) {
+
+		stdout, err := p.StdoutPipe()
+		if err != nil {
+			panic(fmt.Sprintf("Error getting tus server stdout: %v", err))
+		}
+		stderr, err := p.StderrPipe()
+		if err != nil {
+			panic(fmt.Sprintf("Error getting tus server stderr: %v", err))
+		}
+		err = p.Start()
+		if err != nil {
+			panic(fmt.Sprintf("Error starting tus server: %v", err))
+		}
+		go func() {
+			scanner := bufio.NewScanner(stdout)
+			for scanner.Scan() {
+				logger.Log(kv{"fn": "tusout", "msg": scanner.Text()})
+			}
+		}()
+		go func() {
+			scanner := bufio.NewScanner(stderr)
+			for scanner.Scan() {
+				logger.Log(kv{"fn": "tuserr", "msg": scanner.Text()})
+			}
+		}()
+		time.Sleep(2)
+		procWait.Done()
+		defer p.Wait()
+
+	}(t.tusProcess)
+	procWait.Wait()
+	logger.Log(kv{"fn": "Start", "msg": "Tus server started"})
+	t.tusBaseUrl = fmt.Sprintf("http://%s:%s/files/", host, port)
+	t.httpClient = &http.Client{}
+	t.oidToTusUrl = make(map[string]string)
+}
+
+func (t *TusServer) Stop() {
+	t.serverMutex.Lock()
+	defer t.serverMutex.Unlock()
+	if t.tusProcess != nil {
+		t.tusProcess.Process.Kill()
+		t.tusProcess = nil
+	}
+	logger.Log(kv{"fn": "Stop", "msg": "Tus server stopped"})
+}
+
+// Create a new upload URL for the given object
+// Required to call CREATE on the tus API before uploading but not part of LFS API
+func (t *TusServer) Create(oid string, size int64) (string, error) {
+	t.serverMutex.Lock()
+	defer t.serverMutex.Unlock()
+	req, err := http.NewRequest("POST", t.tusBaseUrl, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Tus-Resumable", "1.0.0")
+	req.Header.Set("Upload-Length", fmt.Sprintf("%d", size))
+	req.Header.Set("Upload-Metadata", fmt.Sprintf("oid %s", oid))
+
+	res, err := t.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if res.StatusCode != 201 {
+		return "", fmt.Errorf("Expected tus status code 201, got %d", res.StatusCode)
+	}
+	loc := res.Header.Get("Location")
+	if len(loc) == 0 {
+		return "", fmt.Errorf("Missing Location header in tus response")
+	}
+	t.oidToTusUrl[oid] = loc
+	return loc, nil
+}
+
+// Move the finished uploaded data from TUS to the content store (called by verify)
+func (t *TusServer) Finish(oid string, store *ContentStore) error {
+	t.serverMutex.Lock()
+	defer t.serverMutex.Unlock()
+
+	loc, ok := t.oidToTusUrl[oid]
+	if !ok {
+		return fmt.Errorf("Unable to find upload for %s", oid)
+	}
+	parts := strings.Split(loc, "/")
+	filename := filepath.Join(t.dataPath, fmt.Sprintf("%s.bin", parts[len(parts)-1]))
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return err
+	}
+	meta := &MetaObject{Oid: oid, Size: stat.Size(), Existing: false}
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	err = store.Put(meta, f)
+	if err == nil {
+		os.Remove(filename)
+		// tus also stores a .info file, remove that
+		os.Remove(filepath.Join(t.dataPath, fmt.Sprintf("%s.info", parts[len(parts)-1])))
+	}
+	return err
+}


### PR DESCRIPTION
This PR allows the user to opt-in to using `tusd` to enable resumable uploads. `tusd` is the reference implementation of the [tus.io resumable upload protocol](http://tus.io/protocols/resumable-upload.html) and is supported by[ this git-lfs PR](https://github.com/github/git-lfs/pull/1303) which should hopefully be in git-lfs v1.3.

I couldn't create meaningful tests for this without making the project dependent on the tus codebase, which is quite large (recursive dependencies). This is also the reason I chose to implement it by calling the `tusd` binary (which the user must have installed when opting in), rather than directly referencing the tus code - that would have been more elegant and wouldn't have had to assume knowledge of the tusd storage model, but it would have bloated the vendor directory horribly so I consider this the lesser of the two evils. Hope you agree 😄 

I just run it through its paces manually with a test repo instead.